### PR TITLE
Stop using hardcoded currency symbols.

### DIFF
--- a/members/account.hbs
+++ b/members/account.hbs
@@ -38,7 +38,7 @@
             <div class="pico-field">
                 <div class="pico-field-content">
                     <label>Your plan</label>
-                    <div class="pico-field-value">$<span class="gh-plan-price">0</span>/{{plan.interval}}</div>
+                    <div class="pico-field-value">{{@price.currency_symbol}}<span class="gh-plan-price">0</span>/{{plan.interval}}</div>
                 </div>
                 <div class="pico-field-actions">
                     {{!-- <a href="" class="gh-button">Edit</a> --}}

--- a/members/signup.hbs
+++ b/members/signup.hbs
@@ -18,7 +18,7 @@
                 <div class="gh-checkout-plan">
                     <header class="gh-checkout-plan-header">
                         <h3>Monthly</h3>
-                        <span>$</span><strong>{{@price.monthly}}</strong> / month
+                        <span>{{@price.currency_symbol}}</span><strong>{{@price.monthly}}</strong> / month
                     </header>
                     <div class="gh-checkout-plan-content">
                         <ul>
@@ -36,7 +36,7 @@
                 <div class="gh-checkout-plan">
                     <header class="gh-checkout-plan-header">
                         <h3>Yearly</h3>
-                        <span>$</span><strong>{{@price.yearly}}</strong> / year
+                        <span>{{@price.currency_symbol}}</span><strong>{{@price.yearly}}</strong> / year
                     </header>
                     <div class="gh-checkout-plan-content">
                         <ul>


### PR DESCRIPTION
Since Ghost supports multiple currencies, it makes sense to swap out the existing currency symbols with the handlebars-equivalent. Closes #33, too.