### PR TITLE
Adopt the shared Renovate theme preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>TryGhost/renovate-config"]
+  "extends": [
+    "local>TryGhost/renovate-config:theme.json5"
+  ]
 }


### PR DESCRIPTION
Adopts the shared Renovate preset `local>TryGhost/renovate-config:theme.json5` so dependency updates are kept current automatically.

Part of the `cleanrepos rollout renovate --type theme` batch. Review the `renovate.json` change and merge when ready.
