### PR TITLE
Fixed broken pnpm/action-setup pin and excluded workspace file from zip

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,8 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!pnpm-debug.log',
-            '!pnpm-lock.yaml'
+            '!pnpm-lock.yaml',
+            '!pnpm-workspace.yaml'
         ]),
         zip(filename),
         dest(targetDir)


### PR DESCRIPTION
## Summary

- Replaced the `pnpm/action-setup` pin `ac6db6d3c1f721f886538a378a2d73e85697340a` with `0e279bb959325dab635dd2c09392533439d90093` in both workflows. The old digest no longer exists upstream (GitHub returns HTTP 422), so jobs using it fail to resolve the action. The new digest is the verified commit behind the current `v6`/`v6.0.8` tag. Discovered via CodeRabbit during the monorepo pnpm migration in TryGhost/Themes#529.
- Added `'!pnpm-workspace.yaml'` to the gulp zip task exclusions. The file only carries pnpm 11 build-script approvals (development tooling) and should not ship in the installable theme zip.

## Verification

- `gh api repos/pnpm/action-setup/commits/0e279bb...` resolves; the old `ac6db6d...` digest returns HTTP 422, confirming the breakage and the fix.
- `pnpm install --frozen-lockfile` succeeded.
- `pnpm zip` built `dist/pico.zip`; `unzip -l` confirms no `pnpm-*` files (no `pnpm-workspace.yaml`, `pnpm-lock.yaml`, or `pnpm-debug.log`) in the archive.
- Regenerated `assets/built/` output was restored so the diff stays scoped to the two fixes.