### PR TITLE
Renamed CI gate check to org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
       # are fixed, then switch this back to `pnpm test`.
       - run: pnpm test:ci
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires a status check named exactly `All tests pass`. Requiring an individual/legacy check name couples branch protection to this repo's CI naming: rename the job and the required check silently stops existing, blocking every PR.

The org is standardizing every repo on a single stable aggregator check named `Required checks pass` (the `repo-ci-required-check` convention), so rulesets can require one context everywhere regardless of how each repo's test matrix evolves.

## What

- Renames the aggregator job `all-tests-pass` (`name: All tests pass`) to `required-checks-pass` (`name: Required checks pass`) in `.github/workflows/test.yml`.
- Gate shape is unchanged and already matches the convention: `if: always()`, `needs: [test]` (the only other job in the workflow), single verify step failing on any `failure`/`cancelled` result. Top-level `permissions: contents: read` was already present.

## Note

The branch ruleset is being updated in the same pass to require `Required checks pass` instead of `All tests pass`, so this PR must go green on the new gate before merge.